### PR TITLE
Suggestion: return a 204 No Content response

### DIFF
--- a/src/Http/Controllers/LaravelCaffeineController.php
+++ b/src/Http/Controllers/LaravelCaffeineController.php
@@ -4,8 +4,13 @@ use Illuminate\Routing\Controller;
 
 class LaravelCaffeineController extends Controller
 {
+    /**
+     * Keep the session from timing out.
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     public function drip()
     {
-        return 'true';
+        return response('', 204);
     }
 }


### PR DESCRIPTION
Instead of sending a 200 OK with a 'true' string response, I think it makes much more sense to send a 204 with an empty response.