### PR TITLE
preg_match correction in Middleware

### DIFF
--- a/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
+++ b/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
@@ -29,7 +29,7 @@ class LaravelCaffeineDripMiddleware
 
         if (is_string($content)
             && (strpos($content, '_token')
-                || (preg_match("\<meta name=[\"\']csrf[_-]token[\"\']", $content)))) {
+                || (preg_match("/<meta name=[\"\']csrf[_-]token[\"\']/", $content)))) {
             $newContent = "<script>setInterval(function(){";
             $newContent .= "var e=window.XMLHttpRequest?new XMLHttpRequest:new ActiveXObject('Microsoft.XMLHTTP');";
             $newContent .= "e.open('GET','" . url('/genealabs/laravel-caffeine/drip') . "',!0);";


### PR DESCRIPTION
I think this can fix the preg_match error

```php
preg_match(): Delimiter must not be alphanumeric or backslash
```