### PR TITLE
Allows you to set middleware in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The following elements are configurable:
  the drip URL in the browser. This is just cosmetic.
 - **dripIntervalInMilliSeconds:** (default: 5 mins) Change to configure the drip
  interval.
+- **middleware:** (default: 5 mins) Change to set the middleware for the drip route to be grouped into.
+ Defaults to web if web exists, otherwise it is not grouped.
 
 ___Only publish the config file it you need to customize it___:
 ```sh

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following elements are configurable:
  the drip URL in the browser. This is just cosmetic.
 - **dripIntervalInMilliSeconds:** (default: 5 mins) Change to configure the drip
  interval.
-- **middleware:** (default: 5 mins) Change to set the middleware for the drip route to be grouped into.
+- **middleware:** (default: NULL|web) Change to set the middleware for the drip route to be grouped into.
  Defaults to web if web exists, otherwise it is not grouped.
 
 ___Only publish the config file it you need to customize it___:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-4": {
             "GeneaLabs\\LaravelCaffeine\\": "src/"
         }
-    },ó
+    },
     "require": {
         "php": ">=7.0.0",
         "illuminate/config": "5.1.* || 5.3.*",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
         "psr-4": {
             "GeneaLabs\\LaravelCaffeine\\": "src/"
         }
-    },
+    },ó
     "require": {
         "php": ">=7.0.0",
+        "illuminate/config": "5.1.* || 5.3.*",
         "illuminate/support": "5.1.* || 5.3.*",
         "illuminate/routing": "5.1.* || 5.3.*"
     }

--- a/config/genealabs-laravel-caffeine.php
+++ b/config/genealabs-laravel-caffeine.php
@@ -1,8 +1,28 @@
 <?php
 
 return [
-    'dripIntervalInMilliSeconds' => 300000,         // every 5 minutes
-    'domain' => null,                               // defaults to url('/')
-    'route' => 'genealabs/laravel-caffeine/drip',   // can be customized
-    'middleware' => null,                           //
+    /**
+     * Interval in which the drip AJAX request will run, provided in milliseconds.
+     *
+     * Default: 5 minutes
+     */
+    'dripIntervalInMilliSeconds' => 300000,
+
+    /**
+     * Change to point to a different domain than your app. This is useful if you are behind a proxy or load-balancer.
+     *
+     * Default: url('/')
+     */
+    'domain' => null,
+
+    /**
+     * Change to customize the drip URL in the browser. This is just cosmetic.
+     */
+    'route' => 'genealabs/laravel-caffeine/drip',
+
+    /**
+     * Change to set the middleware for the drip route to be grouped into. Defaults to web if web exists, otherwise
+     * it is not grouped.
+     */
+    'middleware' => null,
 ];

--- a/config/genealabs-laravel-caffeine.php
+++ b/config/genealabs-laravel-caffeine.php
@@ -4,4 +4,5 @@ return [
     'dripIntervalInMilliSeconds' => 300000,         // every 5 minutes
     'domain' => null,                               // defaults to url('/')
     'route' => 'genealabs/laravel-caffeine/drip',   // can be customized
+    'middleware' => null,                           //
 ];

--- a/src/Providers/LaravelCaffeineService.php
+++ b/src/Providers/LaravelCaffeineService.php
@@ -40,7 +40,7 @@ class LaravelCaffeineService extends ServiceProvider
         $middleware_config = app(Cache::class)->get('genealabs-laravel-caffeine.middleware');
 
         if ($middleware_config) {
-            return is_array($middleware_config) ? $middleware_config : ['middleware' => $middleware_config];
+            return ['middleware' => $middleware_config];
         }
 
         return $this->middlewareGroupExists('web') ? ['middleware' => 'web'] : [];


### PR DESCRIPTION
This PR allows you to set a middleware group via the configuration file as well as commenting improvements to the default config.

Also a workaround for https://github.com/GeneaLabs/laravel-caffeine/issues/47 as I don't have the time to find the root cause at the moment.