### PR TITLE
Supporting Laravel 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=7.0.0",
-        "illuminate/support": "5.1.* || 5.3.*",
-        "illuminate/routing": "5.1.* || 5.3.*"
+        "illuminate/support": "5.1.* || 5.3.* || 5.4.*",
+        "illuminate/routing": "5.1.* || 5.3.* || 5.4.*"
     }
 }


### PR DESCRIPTION
Seemingly the only barrier for supporting Laravel 5.4 is the outdated Composer JSON.