### PR TITLE
Reload the Page if we miss the Drip

### DIFF
--- a/config/genealabs-laravel-caffeine.php
+++ b/config/genealabs-laravel-caffeine.php
@@ -4,6 +4,6 @@ return [
     'dripIntervalInMilliSeconds' => 300000,         // Drip every 5 minutes
     'domain' => null,                               // defaults to url('/')
     'route' => 'genealabs/laravel-caffeine/drip',   // Can be customized
-    'thresholdDifference' => 60000,                 // When the drip will be considered old to reload the page
+    'thresholdDifference' => 10000,                 // When the drip will be considered old to reload the page
     'checkLastDripInterval' => 2000                 // How often we will check if the drip is old
 ];

--- a/config/genealabs-laravel-caffeine.php
+++ b/config/genealabs-laravel-caffeine.php
@@ -1,7 +1,9 @@
 <?php
 
 return [
-    'dripIntervalInMilliSeconds' => 300000,         // every 5 minutes
+    'dripIntervalInMilliSeconds' => 300000,         // Drip every 5 minutes
     'domain' => null,                               // defaults to url('/')
-    'route' => 'genealabs/laravel-caffeine/drip',   // can be customized
+    'route' => 'genealabs/laravel-caffeine/drip',   // Can be customized
+    'thresholdDifference' => 60000,                 // When the drip will be considered old to reload the page
+    'checkLastDripInterval' => 2000                 // How often we will check if the drip is old
 ];

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -42,7 +42,7 @@ class Dripper extends Model
         );
     }
     
-    public function getThreshold() : int
+    public function getThresholdAttribute() : int
     {
         return config(
             'genealabs-laravel-caffeine.thresholdDifference',
@@ -50,7 +50,7 @@ class Dripper extends Model
         );
     }
     
-    public function getCheckInterval : int
+    public function getCheckIntervalAttribute() : int
     {
         return config(
             'genealabs-laravel-caffeine.checkLastDripInterval',

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -11,11 +11,27 @@ class Dripper extends Model
 {
     public function getHtmlAttribute() : string
     {
-        return '<script>setInterval(function(){'
-            . "var e=window.XMLHttpRequest?new XMLHttpRequest:new ActiveXObject('Microsoft.XMLHTTP');"
-            . "e.open('GET','{$this->url}',!0);"
-            . "e.setRequestHeader('X-Requested-With','XMLHttpRequest');"
-            . "e.send();}, {$this->interval});</script>";
+        
+        return '<script>'
+            . "let caffeineLastDrip = new Date();"
+            . "function caffeineSendDrip () {"
+            . "    let e = window.XMLHttpRequest ? new XMLHttpRequest : new ActiveXObject('Microsoft.XMLHTTP');"
+            . "    e.onreadystatechange = function () {"
+            . "        if (e.readyState === 4 && e.status === 204) {"
+            . "            caffeineLastDrip = new Date();"
+            . "        }"
+            . "    };"
+            . "    e.open('GET', '{$this->url}', !0);"
+            . "    e.setRequestHeader('X-Requested-With', 'XMLHttpRequest');"
+            . "    e.send();"
+            . "}"
+            . "setInterval(caffeineSendDrip()), $this->interval);"
+            . "setInterval(function () {"
+            . "    if (new Date() - caffeineLastDrip >= $this->threshold ) {"
+            . "        location.reload(true);"
+            . "    }"
+            . "}, $this->checkInterval);"
+            . "</script>";
     }
 
     public function getIntervalAttribute() : string
@@ -23,6 +39,22 @@ class Dripper extends Model
         return config(
             'genealabs-laravel-caffeine.dripIntervalInMilliSeconds',
             300000
+        );
+    }
+    
+    public function getThreshold() : int
+    {
+        return config(
+            'genealabs-laravel-caffeine.thresholdDifference',
+            60000
+        );
+    }
+    
+    public function getCheckInterval : int
+    {
+        return config(
+            'genealabs-laravel-caffeine.checkLastDripInterval',
+            2000
         );
     }
 

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -46,7 +46,7 @@ class Dripper extends Model
     {
         return config(
             'genealabs-laravel-caffeine.thresholdDifference',
-            60000
+            10000
         );
     }
     

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -27,7 +27,7 @@ class Dripper extends Model
             . "}"
             . "setInterval(function () { caffeineSendDrip(); }, $this->interval);"
             . "setInterval(function () {"
-            . "    if (new Date() - ld >= $this->interval + $this->threshold ) {"
+            . "    if (new Date() - ld >= $this->threshold ) {"
             . "        location.reload(true);"
             . "    }"
             . "}, $this->checkInterval);"

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -13,12 +13,12 @@ class Dripper extends Model
     {
         
         return '<script>'
-            . "let caffeineLastDrip = new Date();"
+            . "let ld = new Date();"
             . "function caffeineSendDrip () {"
             . "    let e = window.XMLHttpRequest ? new XMLHttpRequest : new ActiveXObject('Microsoft.XMLHTTP');"
             . "    e.onreadystatechange = function () {"
             . "        if (e.readyState === 4 && e.status === 204) {"
-            . "            caffeineLastDrip = new Date();"
+            . "            ld = new Date();"
             . "        }"
             . "    };"
             . "    e.open('GET', '{$this->url}', !0);"
@@ -27,7 +27,7 @@ class Dripper extends Model
             . "}"
             . "setInterval(function () { caffeineSendDrip(); }, $this->interval);"
             . "setInterval(function () {"
-            . "    if (new Date() - caffeineLastDrip >= $this->threshold ) {"
+            . "    if (new Date() - ld >= $this->threshold ) {"
             . "        location.reload(true);"
             . "    }"
             . "}, $this->checkInterval);"

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -25,7 +25,7 @@ class Dripper extends Model
             . "    e.setRequestHeader('X-Requested-With', 'XMLHttpRequest');"
             . "    e.send();"
             . "}"
-            . "setInterval(caffeineSendDrip()), $this->interval);"
+            . "setInterval(function () { caffeineSendDrip(); }, $this->interval);"
             . "setInterval(function () {"
             . "    if (new Date() - caffeineLastDrip >= $this->threshold ) {"
             . "        location.reload(true);"

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -27,7 +27,7 @@ class Dripper extends Model
             . "}"
             . "setInterval(function () { caffeineSendDrip(); }, $this->interval);"
             . "setInterval(function () {"
-            . "    if (new Date() - ld >= $this->threshold ) {"
+            . "    if (new Date() - ld >= $this->interval + $this->threshold ) {"
             . "        location.reload(true);"
             . "    }"
             . "}, $this->checkInterval);"

--- a/src/Dripper.php
+++ b/src/Dripper.php
@@ -27,7 +27,7 @@ class Dripper extends Model
             . "}"
             . "setInterval(function () { caffeineSendDrip(); }, $this->interval);"
             . "setInterval(function () {"
-            . "    if (new Date() - ld >= $this->threshold ) {"
+            . "    if (new Date() - ld >= $this->interval + $this->threshold) {"
             . "        location.reload(true);"
             . "    }"
             . "}, $this->checkInterval);"


### PR DESCRIPTION
Caffeine now will reload the page if the last drip misses, something that happen when the device (laptops, smartphones) go to sleep, halting the browser activity - in this case, pausing Caffeine Drip interval.

This is accomplished in this way;

1) Save when the Last Drip was sent and successfully acknowledged (server code 204).
2) Check every 2 seconds if the Last Drip sent is old/missed by 10 seconds.
3) If the latter is true, reload the page for a new `csrf_token`.

This allows to evade `TokenMismatchException`, that happens when the client requests with an invalid (old) `csrf_token` after long time of network inactivity.

If the page gets reloaded when there is no network connectivity, the browser is intelligent enough (at least on Chrome) to retrieve the page entirely once the connection reestablishes.

The Check Interval and the old/miss Threshold are configurable under the same config array, so it's not necessary to match it up to the application session lifetime.

Happy Holidays.