### PR TITLE
Make caffeine compatible with older browsers

### DIFF
--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -1,7 +1,7 @@
 <script>
-    let lastCheck = new Date();
-    const caffeineSendDrip = function () {
-        const ajax = window.XMLHttpRequest
+    var lastCheck = new Date();
+    var caffeineSendDrip = function () {
+        var ajax = window.XMLHttpRequest
             ? new XMLHttpRequest
             : new ActiveXObject('Microsoft.XMLHTTP');
 

--- a/tests/Feature/CaffeineTest.php
+++ b/tests/Feature/CaffeineTest.php
@@ -79,7 +79,7 @@ class CaffeineTest extends FeatureTestCase
             $html
         );
         $hasDripper = (bool) preg_match(
-            '/\bconst caffeineSendDrip\b/',
+            '/\bvar caffeineSendDrip\b/',
             $html
         );
 
@@ -91,7 +91,7 @@ class CaffeineTest extends FeatureTestCase
     {
         $response = $this->get(route('genealabs-laravel-caffeine.tests.null-response'));
 
-        $response->dontSee('const caffeineSendDrip');
+        $response->dontSee('var caffeineSendDrip');
     }
 
     public function testRouteMiddleware()
@@ -104,6 +104,6 @@ class CaffeineTest extends FeatureTestCase
         $response = $this
             ->get(route('genealabs-laravel-caffeine.tests.route-middleware'));
 
-        $response->see('const caffeineSendDrip');
+        $response->see('var caffeineSendDrip');
     }
 }

--- a/tests/Fixtures/expired_script.txt
+++ b/tests/Fixtures/expired_script.txt
@@ -1,7 +1,7 @@
 <script>
-    let lastCheck = new Date();
-    const caffeineSendDrip = function () {
-        const ajax = window.XMLHttpRequest
+    var lastCheck = new Date();
+    var caffeineSendDrip = function () {
+        var ajax = window.XMLHttpRequest
             ? new XMLHttpRequest
             : new ActiveXObject('Microsoft.XMLHTTP');
 

--- a/tests/Fixtures/unexpired_script.txt
+++ b/tests/Fixtures/unexpired_script.txt
@@ -1,7 +1,7 @@
 <script>
-    let lastCheck = new Date();
-    const caffeineSendDrip = function () {
-        const ajax = window.XMLHttpRequest
+    var lastCheck = new Date();
+    var caffeineSendDrip = function () {
+        var ajax = window.XMLHttpRequest
             ? new XMLHttpRequest
             : new ActiveXObject('Microsoft.XMLHTTP');
 


### PR DESCRIPTION
Many older browser does not support let and const language elements so it is required to change them to var.