### PR TITLE
capture original content and restore it after content is set

### DIFF
--- a/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
+++ b/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
@@ -2,6 +2,7 @@
 
 use Closure;
 use GeneaLabs\LaravelCaffeine\Dripper;
+use GeneaLabs\LaravelCaffeine\Http\Response;
 use Illuminate\Http\Request;
 
 class LaravelCaffeineDripMiddleware
@@ -47,7 +48,8 @@ class LaravelCaffeineDripMiddleware
             "{$dripper->html}</body>",
             $content
         );
-        $response->setContent($content);
+
+        $this->setContents($response, $content);
 
         return $response;
     }
@@ -55,5 +57,18 @@ class LaravelCaffeineDripMiddleware
     protected function makeRegex(array $regexp) : string
     {
         return '/' . implode('', $regexp) . '/';
+    }
+
+    /**
+     * @param $response
+     * @param $content
+     */
+    protected function setContents($response, $content): void
+    {
+        $original = $response->original;
+
+        $response->setContent($content);
+
+        $response->original = $original;
     }
 }

--- a/tests/Feature/CaffeineTest.php
+++ b/tests/Feature/CaffeineTest.php
@@ -21,6 +21,7 @@ class CaffeineTest extends FeatureTestCase
         $response = $this->get(route('genealabs-laravel-caffeine.tests.form'));
 
         $response->see($expectedResult);
+        $response->assertViewHas('foo');
     }
 
     public function testSuccessfulDrip()

--- a/tests/Http/Controllers/Test.php
+++ b/tests/Http/Controllers/Test.php
@@ -10,7 +10,7 @@ class Test extends Controller
         config()->set('session.lifetime', 1);
         config()->set('genealabs-laravel-caffeine.drip-interval', 50000);
 
-        return view('genealabs-laravel-caffeine::tests.form');
+        return view('genealabs-laravel-caffeine::tests.form')->with('foo');
     }
 
     public function disabledPage() : View


### PR DESCRIPTION
The `original` field is reset in the response when calling `setContent`, and so the field goes from containing an instance of Illuminate\View to being a string. Laravel test helpers such as `assertViewHas` checks the original field for an instance of View. This PR retains the original field and restores it after the contents are set.