### PR TITLE
Update composer dependencies for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,20 +9,20 @@
         }
     ],
     "require": {
-        "illuminate/routing": "5.3 - 5.6",
-        "illuminate/support": "5.3 - 5.6",
+        "illuminate/routing": "5.3 - 5.7",
+        "illuminate/support": "5.3 - 5.7",
         "jenssegers/model": "*",
         "php": ">=7.1.3"
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "*",
         "mockery/mockery": "0.9.*",
-        "orchestra/testbench-browser-kit": "^3.6",
-        "orchestra/testbench-dusk": "3.6.x-dev@dev",
-        "orchestra/testbench": "^3.6",
+        "orchestra/testbench-browser-kit": "3.7.x-dev@dev",
+        "orchestra/testbench-dusk": "3.7.x-dev@dev",
+        "orchestra/testbench": "^3.7",
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "*",
-        "satooshi/php-coveralls" : "*",
+        "php-coveralls/php-coveralls" : "*",
         "sebastian/phpcpd": "*"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
     printerClass="Codedungeon\PHPUnitPrettyResultPrinter\Printer"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
 >
 <testsuites>
     <testsuite name="Browser">


### PR DESCRIPTION
This PR enables the use of this package with Laravel 5.7.     I was not able to get the Dusk tests to run on my local machine, but the Unit and Feature tests are passing. 