### PR TITLE
Allow caffeine to work when the closing tag of body is absent or contains spaces

### DIFF
--- a/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
+++ b/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
@@ -42,11 +42,18 @@ class LaravelCaffeineDripMiddleware
         }
 
         $dripper = (new Dripper);
-        $content = str_replace(
-            '</body>',
-            "{$dripper->html}</body>",
-            $content
-        );
+        
+        if (\strpos($content, '</body') !== false) {
+            $content = str_replace(
+                '</body',
+                "{$dripper->html}</body",
+                $content
+            );
+        }
+        else {
+            $content .= $dripper->html;
+        }
+            
         $original = $response->original;
         $response->setContent($content);
         $response->original = $original;

--- a/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
+++ b/src/Http/Middleware/LaravelCaffeineDripMiddleware.php
@@ -42,18 +42,13 @@ class LaravelCaffeineDripMiddleware
         }
 
         $dripper = (new Dripper);
+        $content = preg_replace(
+            '/(<\/body|<\/html|\Z)/', 
+            $dripper->html'.'$1', 
+            $content, 
+            1
+        );
         
-        if (\strpos($content, '</body') !== false) {
-            $content = str_replace(
-                '</body',
-                "{$dripper->html}</body",
-                $content
-            );
-        }
-        else {
-            $content .= $dripper->html;
-        }
-            
         $original = $response->original;
         $response->setContent($content);
         $response->original = $original;


### PR DESCRIPTION
Maybe my approach is a bit naive, but I think we can just check if `</body` is found in content and if it's not, just append the dripper HTML at the end of content.

Spaces after tag name are also valid in html (even when closing tags), so I propose to work with `</body` instead of `</body>`.

This resolves #105 