### PR TITLE
Use csp_nonce() from spatie/laravel-csp if available

### DIFF
--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -1,4 +1,4 @@
-<script>
+<script @if(function_exists('csp_nonce'))nonce="{{ csp_nonce() }}"@endif >
     var lastCheck = new Date();
     var caffeineSendDrip = function () {
         var ajax = window.XMLHttpRequest


### PR DESCRIPTION
When using spatie/laravel-csp or a CSP policy that uses nonce, genealabs/laravel-caffeine does not work. This change uses the csp_nonce() function from spatie/laravel-csp to generate the value and generates a nonce attribute to the script tag.

Probably not the most elegant or portable solution but it is what I could come up with to make it work for me. I am open to suggestions on what else to do in order to achieve this. I thought of adding a new configuration variable that triggers the nonce attribute and uses the configuration variable's value as the nonce value.