### PR TITLE
Update jenssegers/model dependency to v1.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,6 @@
             ]
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,6 @@
             ]
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -8,27 +8,10 @@
             "email": "hello@genealabs.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "jenssegers/model",
-                "version": "dev-master",
-                "source": {
-                    "url": "https://github.com/Kyzegs/model.git",
-                    "type": "git",
-                    "reference": "master"
-                },
-                "autoload": {
-                    "classmap": [""]
-                }
-            }
-        }
-    ],
     "require": {
         "illuminate/routing": "^10.0",
         "illuminate/support": "^10.0",
-        "jenssegers/model": "dev-master@dev"
+        "jenssegers/model": "^1.5"
     },
     "require-dev": {
         "orchestra/testbench-browser-kit": "^8.0",


### PR DESCRIPTION
Title says all :-)

Include the latest jenssegers/model dependency update from the original repository yet again.

Also fixes #145.