### PR TITLE
feat(php): Add PHP 8.5 support

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.2]
+        php: [8.5, 8.4, 8.3, 8.2]
 
     name: PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This package adds the routes under `genealabs/laravel-caffeine`.
 ### Dependencies
 Your project must fullfill the following:
 - Laravel 8.0 or higher
-- PHP 7.3 or higher.
+- PHP 8.2 or higher (including PHP 8.5).
 
 ## Installation
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": "^8.2",
         "illuminate/routing": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0"
     },


### PR DESCRIPTION
## Summary
Add PHP 8.5 support to the package by updating the composer.json PHP constraint, adding PHP 8.5 to the CI matrix, resolving any deprecation warnings, and updating the README version support documentation.

## Acceptance Criteria
- [x] `composer.json` version constraint updated to include PHP 8.5 (e.g. `^8.2|^8.5` or `>=8.2`)
- [x] CI matrix includes a PHP 8.5 job and all tests pass with zero failures on PHP 8.5
- [x] Any PHP 8.5 deprecation warnings or compatibility issues in package source are resolved
- [x] README version support table updated to include PHP 8.5
- [x] `composer update` completes without conflicts under PHP 8.5

Fixes #164